### PR TITLE
feat: custom user-defined secret patterns

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -240,6 +240,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,10 +268,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "hashbrown"
@@ -267,12 +308,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -306,6 +362,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +429,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -414,6 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +526,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
@@ -475,6 +577,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,10 +609,18 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -543,6 +666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +713,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +753,47 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -677,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +891,24 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -743,6 +953,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -885,6 +1129,103 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 # Error handling
 anyhow = "1"
@@ -44,6 +45,9 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Colors for terminal output
 colored = "2"
+
+[dev-dependencies]
+tempfile = "3"
 
 [profile.release]
 opt-level = 3

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -86,7 +86,7 @@ enum Commands {
         limit: usize,
     },
 
-    /// List all built-in patterns
+    /// List all active patterns (built-in + custom)
     Patterns,
 
     /// Auto-install hook into ~/.claude/settings.json
@@ -311,27 +311,44 @@ fn main() -> Result<()> {
         }
 
         Commands::Patterns => {
+            let builtin_count = *patterns::BUILTIN_COUNT;
+            let total = patterns::PATTERNS.len();
+            let custom_count = total - builtin_count;
+
             if cli.json {
-                let list: Vec<_> = patterns::PATTERNS.iter().map(|p| {
+                let list: Vec<_> = patterns::PATTERNS.iter().enumerate().map(|(i, p)| {
                     serde_json::json!({
                         "id": p.id,
                         "name": p.name,
-                        "severity": p.severity.as_str()
+                        "severity": p.severity.as_str(),
+                        "source": patterns::pattern_source(i)
                     })
                 }).collect();
                 println!("{}", serde_json::to_string_pretty(&list)?);
                 return Ok(());
             }
 
-            println!("{}", format!("Built-in patterns ({}):", patterns::PATTERNS.len()).bold());
-            println!("{}", "─".repeat(65));
-            for p in patterns::PATTERNS.iter() {
+            println!(
+                "{}",
+                format!(
+                    "Active patterns ({total}): {builtin_count} built-in, {custom_count} custom"
+                ).bold()
+            );
+            println!("{}", "─".repeat(75));
+            for (i, p) in patterns::PATTERNS.iter().enumerate() {
+                let source = patterns::pattern_source(i);
+                let source_tag = if source == "custom" {
+                    "[custom]".yellow().to_string()
+                } else {
+                    String::new()
+                };
                 println!(
-                    "  {} {:8}  {:<20}  {}",
+                    "  {} {:8}  {:<20}  {}  {}",
                     p.severity.emoji(),
                     format!("[{}]", p.severity.as_str().to_uppercase()),
                     p.id,
-                    p.name
+                    p.name,
+                    source_tag
                 );
             }
         }

--- a/core/src/patterns/custom.rs
+++ b/core/src/patterns/custom.rs
@@ -1,0 +1,152 @@
+//! Load user-defined patterns from ~/.secretscan/patterns.toml
+
+use crate::Severity;
+use regex::Regex;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+use super::Pattern;
+
+/// On-disk representation of a custom pattern.
+#[derive(Debug, Deserialize)]
+struct PatternEntry {
+    name: String,
+    regex: String,
+    severity: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    min_entropy: Option<f64>,
+}
+
+/// Top-level config file structure.
+#[derive(Debug, Deserialize)]
+struct ConfigFile {
+    #[serde(default)]
+    patterns: Vec<PatternEntry>,
+}
+
+/// Default config path: ~/.secretscan/patterns.toml
+pub fn default_config_path() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(PathBuf::from(home).join(".secretscan/patterns.toml"))
+}
+
+/// Load custom patterns from the config file.
+///
+/// Returns an empty vec if the file doesn't exist.
+/// Warns and skips individual patterns with invalid regex.
+pub fn load_custom_patterns() -> Vec<Pattern> {
+    let Some(path) = default_config_path() else {
+        return Vec::new();
+    };
+    load_from_path(&path)
+}
+
+/// Load custom patterns from a specific path (testable).
+pub fn load_from_path(path: &Path) -> Vec<Pattern> {
+    if !path.exists() {
+        return Vec::new();
+    }
+
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to read {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+
+    let config: ConfigFile = match toml::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to parse {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+
+    info!("Loading {} custom pattern(s) from {}", config.patterns.len(), path.display());
+
+    let mut result = Vec::new();
+    for entry in config.patterns {
+        let regex = match Regex::new(&entry.regex) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Skipping custom pattern '{}': invalid regex: {e}", entry.name);
+                continue;
+            }
+        };
+
+        let severity = parse_severity(&entry.severity);
+
+        // Leak strings so they live for 'static — these are loaded once at startup.
+        let id: &'static str = Box::leak(entry.name.clone().into_boxed_str());
+        let name: &'static str = match entry.description {
+            Some(d) => Box::leak(d.into_boxed_str()),
+            None => id,
+        };
+
+        result.push(Pattern {
+            id,
+            name,
+            severity,
+            regex,
+            min_entropy: entry.min_entropy,
+            context_keywords: &[],
+        });
+    }
+
+    result
+}
+
+fn parse_severity(s: &str) -> Severity {
+    match s.to_lowercase().as_str() {
+        "low" => Severity::Low,
+        "medium" | "med" => Severity::Medium,
+        "high" => Severity::High,
+        "critical" | "crit" => Severity::Critical,
+        other => {
+            warn!("Unknown severity '{other}', defaulting to Medium");
+            Severity::Medium
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_load_valid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("patterns.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, r#"
+[[patterns]]
+name = "internal_token"
+regex = "itk_[a-zA-Z0-9]{{32}}"
+severity = "high"
+description = "Internal API Token"
+
+[[patterns]]
+name = "bad_regex"
+regex = "[invalid("
+severity = "low"
+"#).unwrap();
+
+        let patterns = load_from_path(&path);
+        // Should load 1 valid pattern, skip the bad regex
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].id, "internal_token");
+        assert_eq!(patterns[0].name, "Internal API Token");
+        assert_eq!(patterns[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let patterns = load_from_path(Path::new("/nonexistent/patterns.toml"));
+        assert!(patterns.is_empty());
+    }
+}

--- a/core/src/patterns/mod.rs
+++ b/core/src/patterns/mod.rs
@@ -1,4 +1,5 @@
 pub mod builtin;
+pub mod custom;
 pub mod entropy;
 
 use crate::{Finding, Severity};
@@ -49,8 +50,24 @@ impl Pattern {
     }
 }
 
-/// All compiled built-in patterns, initialised once.
-pub static PATTERNS: Lazy<Vec<Pattern>> = Lazy::new(builtin::all_patterns);
+/// Number of built-in patterns (set once at init).
+pub static BUILTIN_COUNT: Lazy<usize> = Lazy::new(|| builtin::all_patterns().len());
+
+/// All compiled patterns (built-in + custom), initialised once.
+pub static PATTERNS: Lazy<Vec<Pattern>> = Lazy::new(|| {
+    let mut patterns = builtin::all_patterns();
+    let custom = custom::load_custom_patterns();
+    if !custom.is_empty() {
+        tracing::info!("Loaded {} custom pattern(s)", custom.len());
+    }
+    patterns.extend(custom);
+    patterns
+});
+
+/// Returns whether a pattern at the given index is built-in or custom.
+pub fn pattern_source(index: usize) -> &'static str {
+    if index < *BUILTIN_COUNT { "built-in" } else { "custom" }
+}
 
 /// Scan text against all registered patterns.
 pub fn scan_all(text: &str) -> Vec<Finding> {


### PR DESCRIPTION
## Summary
- Add support for custom user-defined secret patterns loaded from `~/.secretscan/patterns.toml`
- Each custom pattern supports: `name`, `regex`, `severity` (low/medium/high/critical), `description`, and optional `min_entropy`
- Custom patterns are merged with built-in patterns at startup; invalid regex patterns are warned about and skipped
- Update `secretscan patterns` command to show source (built-in vs custom) for each pattern, with `[custom]` tag and JSON `source` field

## Config format

```toml
[[patterns]]
name = "internal_token"
regex = "itk_[a-zA-Z0-9]{32}"
severity = "high"
description = "Internal API Token"
```

## Test plan
- [x] Unit tests for valid config loading and invalid regex skipping
- [x] Unit test for missing config file (returns empty vec)
- [x] `cargo test` passes (6/6 tests)
- [x] `cargo build` succeeds
- [ ] Manual: create `~/.secretscan/patterns.toml` with a custom pattern, verify it appears in `secretscan patterns` output and is used during scanning

🤖 Generated with [Claude Code](https://claude.com/claude-code)